### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cline-responder.yml
+++ b/.github/workflows/cline-responder.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   analyze-issue:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     if: github.event.issue.state != 'closed' && (github.event_name == 'issues' || contains(github.event.comment.body, '/analyze'))
     


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/Fadil369/sbs/security/code-scanning/1](https://github.com/Fadil369/sbs/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block for the workflow/job so that the automatically provided `GITHUB_TOKEN` has only the least privileges needed. Here, the job checks out the repository (which needs `contents: read`) and posts issue comments via the GitHub API (which needs `issues: write`). No other write permissions are required.

The best minimal fix without changing functionality is to add a `permissions:` block under the `analyze-issue` job, specifying `contents: read` and `issues: write`. This leaves everything else (steps, environment variables, and script behavior) unchanged while restricting the token so it cannot, for example, push commits or modify other resources. Concretely, in `.github/workflows/cline-responder.yml`, immediately under `analyze-issue:` (before `runs-on:`), add:

```yaml
    permissions:
      contents: read
      issues: write
```

No additional imports, tools, or code changes are needed; this is purely a YAML configuration adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit permissions block to workflow job

- Restrict GITHUB_TOKEN to minimal required privileges

- Grant contents read and issues write permissions only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Job"] -->|"Add permissions block"| B["Restricted Token Scope"]
  B -->|"contents: read"| C["Checkout Repository"]
  B -->|"issues: write"| D["Post Issue Comments"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cline-responder.yml</strong><dd><code>Add explicit permissions to analyze-issue job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cline-responder.yml

<ul><li>Added <code>permissions:</code> block under <code>analyze-issue:</code> job<br> <li> Specified <code>contents: read</code> for repository checkout<br> <li> Specified <code>issues: write</code> for posting issue comments<br> <li> Restricts GITHUB_TOKEN to least privilege principle</ul>


</details>


  </td>
  <td><a href="https://github.com/Fadil369/sbs/pull/10/files#diff-e237cf3495af27adf7dd7e961280b80b8ced7f49f78acc29e4def51f8766cc1e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

